### PR TITLE
Fix Options Operands

### DIFF
--- a/editable.js
+++ b/editable.js
@@ -87,11 +87,11 @@
             validate: function() { return true; },
         };
         
-        //if no arguments are parsed go straight to return functions (shortCircuit)
-        if (options == null) {
+        //if null is parsed go straight to return functions (shortCircuit)
+        if (options === null) {
             var opts = $.extend(true, {}, $.fn.editable.defaults, options, {shortCircuit: true} );
-        } else if (options == undefined) {
-            var opts = $.fn.editable.defaults;
+        } else if (options === undefined) {
+            var opts = $.fn.editable.defaults
         } else {
             var opts = $.extend(true, {}, $.fn.editable.defaults, options );
         }


### PR DESCRIPTION
change `==` to `===` for null vs undefined
