### PR TITLE
Returning false on `toggler_hooks`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bootstrap Editable v1.4
+# Bootstrap Editable v1.4.1
 
 ### Edit-Table, an ajax friendly way of updating dynamic HTML tables
 A simple, customisable JQuery plugin that allows toggling of `<table>` cells to HTML inputs for editing.
@@ -109,6 +109,8 @@ $(document).ready(function() {
     $('.myTable').editable(myTableOptions);
 });
 ```
+
+**Returning false inside the edit or done functions will prevent the fields being converted in to fields and vice-versa**
 
 **Please note that if you specify the `add_hook` as `true` (default) your table's `<th>`'s will each need a class, as when the `<tfoot>` is generated these classes will become each cell's id**
 

--- a/editable.js
+++ b/editable.js
@@ -1,7 +1,7 @@
 /*
  * COPYRIGHT: Edward Selby
  * VERSION: 1.4
- * LAST UPDATED: 13/11/2015
+ * LAST UPDATED: 10/11/2015
  *
  * Required Dependencies:
  * Glyphicons
@@ -358,9 +358,10 @@
                 $(editHook).not('.bound').addClass('bound').on('click', function(e) {
                     e.preventDefault();
                     //call the edit callback
-                    opts.edit.call($this, $(this), rowData($(this)));
-                    //enable the inputs
-                    $this.editable(null).enableInputs($(this));
+                    if(opts.edit.call($this, $(this), rowData($(this))) !== false) {
+                        //enable the inputs
+                        $this.editable(null).enableInputs($(this));
+                    }
                     $(this).trigger('editable.edit');
                     return false;
                 });
@@ -384,9 +385,10 @@
                     //check if fields are valid
                     if($(parsleyContainer).parsley().validate() || !opts.parsleyValidation) {
                         //call the done callback
-                        opts.done.call($this, $(this), rowData($(this)));
-                        //disable the inputs
-                        $this.editable(null).disableInputs($(this));
+                        if(opts.done.call($this, $(this), rowData($(this))) !== false) {
+                            //disable the inputs
+                            $this.editable(null).disableInputs($(this));
+                        }
                         $(this).trigger('editable.done');
                     }
                     return false;


### PR DESCRIPTION
Returning false on `toggler_hooks` now prevents editable from converting fields to inputs and vice-versa
